### PR TITLE
SEC-P0: enforce production-safe runtime defaults

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,11 +1,14 @@
 DJANGO_SECRET_KEY=replace-with-strong-secret
 DJANGO_DEBUG=False
 DJANGO_ALLOWED_HOSTS=your-fly-app.fly.dev,localhost,127.0.0.1
+SESSION_COOKIE_SECURE=True
+CSRF_COOKIE_SECURE=True
 
 DATABASE_URL=postgres://user:password@host:5432/dbname
 DATABASE_SSL_REQUIRE=True
 
-FRONTEND_ORIGIN=https://boomerbill.net
+CORS_ALLOWED_ORIGINS=https://boomerbill.net
+CSRF_TRUSTED_ORIGINS=https://boomerbill.net
 PUBLIC_DOMAIN=boomerbill.net
 SITE_NAME=BoomerBill
 PASSWORD_RESET_CONFIRM_URL=reset-password?uid={uid}&token={token}

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,6 +4,8 @@ DJANGO_ALLOWED_HOSTS=your-fly-app.fly.dev,localhost,127.0.0.1
 SESSION_COOKIE_SECURE=True
 CSRF_COOKIE_SECURE=True
 
+# Leave DATABASE_URL unset in local development to use sqlite.
+# Set DATABASE_URL in production to use Postgres.
 DATABASE_URL=postgres://user:password@host:5432/dbname
 DATABASE_SSL_REQUIRE=True
 

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -6,3 +6,5 @@
 - Updated DB SSL logic in `backend/core/core/settings.py` to apply `sslmode=require` only when the active engine is PostgreSQL.
 - Clarified DB configuration in `backend/.env.example` to document sqlite fallback for local development and Postgres usage in production.
 - Added `backend/DECISION_LOG.md` documenting the database environment strategy and rationale.
+- Updated `ALLOWED_HOSTS` defaults to require explicit production host configuration while preserving local development defaults.
+- Documented production runtime security requirements and validation commands in `backend/README.md`.

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 2026-05-19
+
+### Changed
+- Updated DB SSL logic in `backend/core/core/settings.py` to apply `sslmode=require` only when the active engine is PostgreSQL.
+- Clarified DB configuration in `backend/.env.example` to document sqlite fallback for local development and Postgres usage in production.
+- Added `backend/DECISION_LOG.md` documenting the database environment strategy and rationale.

--- a/backend/DECISION_LOG.md
+++ b/backend/DECISION_LOG.md
@@ -7,3 +7,11 @@
 - Change: Keep `env.db("DATABASE_URL", default=sqlite...)` and apply `sslmode=require` only when the resolved engine is PostgreSQL and `DATABASE_SSL_REQUIRE=True`.
 - Rationale: Prevents Postgres-only SSL options from being applied to sqlite while preserving strict SSL in production.
 - Impact: Local development works without Postgres setup; production keeps secure DB transport settings.
+
+## 2026-05-19 - Production host validation defaults
+
+- Decision: Require explicit `DJANGO_ALLOWED_HOSTS` when `DJANGO_DEBUG=False`.
+- Context: Static local host defaults are safe in development but should not silently satisfy production host policy.
+- Change: Apply local host defaults only when `DJANGO_DEBUG=True`; production defaults to an empty host list unless provided via env.
+- Rationale: Enforces fail-fast behavior for missing production host configuration.
+- Impact: Production startup now fails early when host policy is not explicitly configured.

--- a/backend/DECISION_LOG.md
+++ b/backend/DECISION_LOG.md
@@ -1,0 +1,9 @@
+# Decision Log
+
+## 2026-05-19 - Database engine behavior by environment
+
+- Decision: Use sqlite in development by default and Postgres in production when `DATABASE_URL` is set.
+- Context: The project uses `django-environ` and a mixed local/prod deployment model.
+- Change: Keep `env.db("DATABASE_URL", default=sqlite...)` and apply `sslmode=require` only when the resolved engine is PostgreSQL and `DATABASE_SSL_REQUIRE=True`.
+- Rationale: Prevents Postgres-only SSL options from being applied to sqlite while preserving strict SSL in production.
+- Impact: Local development works without Postgres setup; production keeps secure DB transport settings.

--- a/backend/README.md
+++ b/backend/README.md
@@ -18,6 +18,30 @@ uv run python manage.py migrate
 uv run python manage.py runserver
 ```
 
+## Production Runtime Security Requirements
+
+When `DJANGO_DEBUG=False`, the app enforces production-safe startup checks.
+
+- `DJANGO_SECRET_KEY` must be set to a real secret.
+- `DJANGO_ALLOWED_HOSTS` must be explicitly set (comma-separated list).
+- `DATABASE_URL` should be set to Postgres in production.
+- `DATABASE_SSL_REQUIRE=True` enables `sslmode=require` for Postgres.
+
+Local development remains functional without `DATABASE_URL`; sqlite is used by default.
+
+### Validation commands
+
+```bash
+# Fails: production mode without required secret key
+uv run python manage.py check
+
+# Passes: local dev defaults (sqlite)
+DJANGO_DEBUG=True uv run python manage.py check
+
+# Passes: production-like config with required values
+DJANGO_DEBUG=False DJANGO_SECRET_KEY=test-secret DJANGO_ALLOWED_HOSTS=example.com DATABASE_SSL_REQUIRE=True uv run python manage.py check
+```
+
 ## SendGrid SMTP on Fly
 
 BoomerBill uses Django + Djoser for password recovery emails. No email SDK is needed; Django SMTP is enough.

--- a/backend/core/core/settings.py
+++ b/backend/core/core/settings.py
@@ -8,36 +8,25 @@ import dj_database_url
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-
+#TODO: import and setup django_environ
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/6.0/howto/deployment/checklist/
 
 
-def env_bool(name: str, default: bool = False) -> bool:
-    raw = os.environ.get(name)
-    if raw is None:
-        return default
-    return raw.strip().lower() in {"1", "true", "yes", "on"}
-
-
-def env_list(name: str) -> list[str]:
-    raw = os.environ.get(name, "")
-    return [item.strip() for item in raw.split(",") if item.strip()]
-
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.environ.get(
-    "DJANGO_SECRET_KEY",
-    "django-insecure-ukz=f&9f$fju1yupbp$*es$%5bqaxq**fgdf^li1=qn(hq2&q9",
+    "DJANGO_SECRET_KEY"
 )
 
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = env_bool("DJANGO_DEBUG", True)
+DEBUG = os.environ.get(
+    "DJANGO_DEBUG"
+)
 
-ALLOWED_HOSTS = env_list("DJANGO_ALLOWED_HOSTS")
-if not ALLOWED_HOSTS:
-    ALLOWED_HOSTS = ["127.0.0.1", "localhost", "0.0.0.0", "testserver"]
+ALLOWED_HOSTS = os.environ.get(
+"DJANGO_ALLOWED_HOSTS", ["127.0.0.1", "localhost", "0.0.0.0", "testserver"]
 
+)
 
 # Application definition
 
@@ -164,20 +153,13 @@ DJOSER = {
 DOMAIN = os.environ.get("PUBLIC_DOMAIN", "localhost:4321")
 SITE_NAME = os.environ.get("SITE_NAME", "BoomerBill")
 
-frontend_origin = os.environ.get("FRONTEND_ORIGIN")
-CORS_ALLOWED_ORIGINS = env_list("CORS_ALLOWED_ORIGINS")
-if frontend_origin and frontend_origin not in CORS_ALLOWED_ORIGINS:
-    CORS_ALLOWED_ORIGINS.append(frontend_origin)
+CORS_ALLOWED_ORIGINS = os.environ.get(
+"CORS_ALLOWED_ORIGINS"
+)
 
-if not CORS_ALLOWED_ORIGINS and DEBUG:
-    CORS_ALLOWED_ORIGINS = [
-        "http://localhost:4321",
-        "http://127.0.0.1:4321",
-    ]
-
-CSRF_TRUSTED_ORIGINS = env_list("CSRF_TRUSTED_ORIGINS")
-if frontend_origin and frontend_origin not in CSRF_TRUSTED_ORIGINS:
-    CSRF_TRUSTED_ORIGINS.append(frontend_origin)
+CSRF_TRUSTED_ORIGINS = os.environ.get(
+"CSRF_TRUSTED_ORIGINS"
+)
 
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
@@ -185,6 +167,7 @@ if not DEBUG:
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True
 
+#TODO: refactor this to 
 email_provider = os.environ.get("EMAIL_PROVIDER", "console").strip().lower()
 if email_provider == "smtp":
     EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"

--- a/backend/core/core/settings.py
+++ b/backend/core/core/settings.py
@@ -1,32 +1,36 @@
 """Django settings for core project."""
 
-import os
 from pathlib import Path
 
-import dj_database_url
+import environ
+from django.core.exceptions import ImproperlyConfigured
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-#TODO: import and setup django_environ
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/6.0/howto/deployment/checklist/
+
+env = environ.Env()
+environ.Env.read_env(BASE_DIR.parent / ".env")
 
 
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.get(
-    "DJANGO_SECRET_KEY"
+SECRET_KEY = env("DJANGO_SECRET_KEY", default="unsafe-dev-key")
+
+DEBUG = env.bool("DJANGO_DEBUG", default=False)
+
+ALLOWED_HOSTS = env.list(
+    "DJANGO_ALLOWED_HOSTS",
+    default=["127.0.0.1", "localhost", "0.0.0.0", "testserver"],
 )
 
-DEBUG = os.environ.get(
-    "DJANGO_DEBUG"
-)
+if not DEBUG and SECRET_KEY == "unsafe-dev-key":
+    raise ImproperlyConfigured("DJANGO_SECRET_KEY must be set when DJANGO_DEBUG=False")
 
-ALLOWED_HOSTS = os.environ.get(
-"DJANGO_ALLOWED_HOSTS", ["127.0.0.1", "localhost", "0.0.0.0", "testserver"]
-
-)
+if not DEBUG and not ALLOWED_HOSTS:
+    raise ImproperlyConfigured("DJANGO_ALLOWED_HOSTS must be set when DJANGO_DEBUG=False")
 
 # Application definition
 
@@ -81,19 +85,11 @@ WSGI_APPLICATION = "core.wsgi.application"
 # https://docs.djangoproject.com/en/6.0/ref/settings/#databases
 
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
-    }
+    "default": env.db("DATABASE_URL", default=f"sqlite:///{BASE_DIR / 'db.sqlite3'}")
 }
 
-database_url = os.environ.get("DATABASE_URL")
-if database_url:
-    DATABASES["default"] = dj_database_url.parse(
-        database_url,
-        conn_max_age=600,
-        ssl_require=env_bool("DATABASE_SSL_REQUIRE", False),
-    )
+if env.bool("DATABASE_SSL_REQUIRE", default=False):
+    DATABASES["default"].setdefault("OPTIONS", {})["sslmode"] = "require"
 
 
 # Password validation
@@ -144,43 +140,35 @@ DJOSER = {
         "user_create": "users.serializers.EmailRequiredUserCreateSerializer",
     },
     "LOGIN_FIELD": "username",
-    "PASSWORD_RESET_CONFIRM_URL": os.environ.get(
+    "PASSWORD_RESET_CONFIRM_URL": env(
         "PASSWORD_RESET_CONFIRM_URL",
         "reset-password?uid={uid}&token={token}",
     ),
 }
 
-DOMAIN = os.environ.get("PUBLIC_DOMAIN", "localhost:4321")
-SITE_NAME = os.environ.get("SITE_NAME", "BoomerBill")
+DOMAIN = env("PUBLIC_DOMAIN", default="localhost:4321")
+SITE_NAME = env("SITE_NAME", default="BoomerBill")
 
-CORS_ALLOWED_ORIGINS = os.environ.get(
-"CORS_ALLOWED_ORIGINS"
-)
+CORS_ALLOWED_ORIGINS = env.list("CORS_ALLOWED_ORIGINS", default=[])
 
-CSRF_TRUSTED_ORIGINS = os.environ.get(
-"CSRF_TRUSTED_ORIGINS"
-)
+CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS", default=[])
 
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
-if not DEBUG:
-    SESSION_COOKIE_SECURE = True
-    CSRF_COOKIE_SECURE = True
+SESSION_COOKIE_SECURE = env.bool("SESSION_COOKIE_SECURE", default=not DEBUG)
+CSRF_COOKIE_SECURE = env.bool("CSRF_COOKIE_SECURE", default=not DEBUG)
 
-#TODO: refactor this to 
-email_provider = os.environ.get("EMAIL_PROVIDER", "console").strip().lower()
+email_provider = env("EMAIL_PROVIDER", default="console").strip().lower()
 if email_provider == "smtp":
     EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-    EMAIL_HOST = os.environ.get("EMAIL_HOST", "")
-    EMAIL_PORT = int(os.environ.get("EMAIL_PORT", "587"))
-    EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER", "")
-    EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD", "")
-    EMAIL_USE_TLS = env_bool("EMAIL_USE_TLS", True)
-    EMAIL_USE_SSL = env_bool("EMAIL_USE_SSL", False)
-    EMAIL_TIMEOUT = int(os.environ.get("EMAIL_TIMEOUT", "10"))
+    EMAIL_HOST = env("EMAIL_HOST", default="")
+    EMAIL_PORT = env.int("EMAIL_PORT", default=587)
+    EMAIL_HOST_USER = env("EMAIL_HOST_USER", default="")
+    EMAIL_HOST_PASSWORD = env("EMAIL_HOST_PASSWORD", default="")
+    EMAIL_USE_TLS = env.bool("EMAIL_USE_TLS", default=True)
+    EMAIL_USE_SSL = env.bool("EMAIL_USE_SSL", default=False)
+    EMAIL_TIMEOUT = env.int("EMAIL_TIMEOUT", default=10)
 else:
     EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
-DEFAULT_FROM_EMAIL = os.environ.get(
-    "DEFAULT_FROM_EMAIL", "BoomerBill <noreply@boomerbill.net>"
-)
+DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL", default="BoomerBill <noreply@boomerbill.net>")

--- a/backend/core/core/settings.py
+++ b/backend/core/core/settings.py
@@ -21,10 +21,8 @@ SECRET_KEY = env("DJANGO_SECRET_KEY", default="unsafe-dev-key")
 
 DEBUG = env.bool("DJANGO_DEBUG", default=False)
 
-ALLOWED_HOSTS = env.list(
-    "DJANGO_ALLOWED_HOSTS",
-    default=["127.0.0.1", "localhost", "0.0.0.0", "testserver"],
-)
+default_allowed_hosts = ["127.0.0.1", "localhost", "0.0.0.0", "testserver"] if DEBUG else []
+ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", default=default_allowed_hosts)
 
 if not DEBUG and SECRET_KEY == "unsafe-dev-key":
     raise ImproperlyConfigured("DJANGO_SECRET_KEY must be set when DJANGO_DEBUG=False")

--- a/backend/core/core/settings.py
+++ b/backend/core/core/settings.py
@@ -88,7 +88,10 @@ DATABASES = {
     "default": env.db("DATABASE_URL", default=f"sqlite:///{BASE_DIR / 'db.sqlite3'}")
 }
 
-if env.bool("DATABASE_SSL_REQUIRE", default=False):
+if (
+    DATABASES["default"]["ENGINE"] == "django.db.backends.postgresql"
+    and env.bool("DATABASE_SSL_REQUIRE", default=False)
+):
     DATABASES["default"].setdefault("OPTIONS", {})["sslmode"] = "require"
 
 

--- a/backend/core/core/settings.py
+++ b/backend/core/core/settings.py
@@ -142,7 +142,7 @@ DJOSER = {
     "LOGIN_FIELD": "username",
     "PASSWORD_RESET_CONFIRM_URL": env(
         "PASSWORD_RESET_CONFIRM_URL",
-        "reset-password?uid={uid}&token={token}",
+        default="reset-password?uid={uid}&token={token}",
     ),
 }
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -12,4 +12,5 @@ dependencies = [
     "djoser>=2.3.3",
     "gunicorn>=22.0.0",
     "psycopg[binary]>=3.2.9",
+    "python-environ>=0.4.54",
 ]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -12,5 +12,5 @@ dependencies = [
     "djoser>=2.3.3",
     "gunicorn>=22.0.0",
     "psycopg[binary]>=3.2.9",
-    "python-environ>=0.4.54",
+    "django-environ>=0.11.2",
 ]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -23,6 +23,7 @@ dependencies = [
     { name = "djoser" },
     { name = "gunicorn" },
     { name = "psycopg", extra = ["binary"] },
+    { name = "python-environ" },
 ]
 
 [package.metadata]
@@ -34,6 +35,7 @@ requires-dist = [
     { name = "djoser", specifier = ">=2.3.3" },
     { name = "gunicorn", specifier = ">=22.0.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.9" },
+    { name = "python-environ", specifier = ">=0.4.54" },
 ]
 
 [[package]]
@@ -380,6 +382,12 @@ wheels = [
 crypto = [
     { name = "cryptography" },
 ]
+
+[[package]]
+name = "python-environ"
+version = "0.4.54"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/5d/8d4462fe29d3d3357eaac0f8321b7d0e77d0a4ea64505be1e6a90fba42dc/python-environ-0.4.54.tar.gz", hash = "sha256:6249a14057f95aba3b4906d73276f770e01e659f8098b3f3b34295feac42865b", size = 22947, upload-time = "2020-04-13T06:42:49.443Z" }
 
 [[package]]
 name = "python3-openid"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "boomerbill",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "boomerbill",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Closes #41

## Summary
- Migrate settings env parsing to typed `django-environ` values (`bool`, `list`, `int`) in `backend/core/core/settings.py`.
- Enforce production fail-fast checks for missing/unsafe critical config (`DJANGO_SECRET_KEY`, `DJANGO_ALLOWED_HOSTS` when `DJANGO_DEBUG=False`).
- Preserve local development flow (sqlite fallback) while enforcing production-safe Postgres SSL behavior only for PostgreSQL engine.
- Document production runtime security requirements and validation commands in `backend/README.md`.
- Add project traceability entries in `backend/CHANGELOG.md` and `backend/DECISION_LOG.md`.

## Validation
- `uv run python manage.py check` fails in production-default mode when secret key is missing (expected fail-fast).
- `DJANGO_DEBUG=True uv run python manage.py check` passes for local development defaults.
- `DJANGO_DEBUG=False DJANGO_SECRET_KEY=test-secret DJANGO_ALLOWED_HOSTS=example.com DATABASE_SSL_REQUIRE=True uv run python manage.py check` passes for production-like valid config.
- `env -u DJANGO_ALLOWED_HOSTS DJANGO_DEBUG=False DJANGO_SECRET_KEY=test-secret uv run python manage.py check` fails as expected for missing production host config.

## Notes
- Root `package-lock.json` was removed from this branch to keep scope aligned to backend security runtime defaults.