### PR TITLE
[SEC-P0] Strengthen secret management policy

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -24,6 +24,7 @@ When `DJANGO_DEBUG=False`, the app enforces production-safe startup checks.
 
 - `DJANGO_SECRET_KEY` must be set to a real secret.
 - `DJANGO_ALLOWED_HOSTS` must be explicitly set (comma-separated list).
+- If `EMAIL_PROVIDER=smtp`, `EMAIL_HOST_PASSWORD` must be set.
 - `DATABASE_URL` should be set to Postgres in production.
 - `DATABASE_SSL_REQUIRE=True` enables `sslmode=require` for Postgres.
 
@@ -33,14 +34,22 @@ Local development remains functional without `DATABASE_URL`; sqlite is used by d
 
 ```bash
 # Fails: production mode without required secret key
-uv run python manage.py check
+DJANGO_DEBUG=False DJANGO_ALLOWED_HOSTS=example.com uv run python manage.py check
+
+# Fails: production mode with placeholder secret key
+DJANGO_DEBUG=False DJANGO_SECRET_KEY=replace-with-strong-secret DJANGO_ALLOWED_HOSTS=example.com uv run python manage.py check
+
+# Fails: smtp configured without SMTP password
+DJANGO_DEBUG=False DJANGO_SECRET_KEY=real-secret DJANGO_ALLOWED_HOSTS=example.com EMAIL_PROVIDER=smtp EMAIL_HOST=smtp.sendgrid.net EMAIL_HOST_PASSWORD= uv run python manage.py check
 
 # Passes: local dev defaults (sqlite)
 DJANGO_DEBUG=True uv run python manage.py check
 
 # Passes: production-like config with required values
-DJANGO_DEBUG=False DJANGO_SECRET_KEY=test-secret DJANGO_ALLOWED_HOSTS=example.com DATABASE_SSL_REQUIRE=True uv run python manage.py check
+DJANGO_DEBUG=False DJANGO_SECRET_KEY=real-secret DJANGO_ALLOWED_HOSTS=example.com DATABASE_SSL_REQUIRE=True uv run python manage.py check
 ```
+
+See `backend/SECURITY_RUNBOOK.md` for secret rotation and incident response checklists.
 
 ## SendGrid SMTP on Fly
 

--- a/backend/SECURITY_RUNBOOK.md
+++ b/backend/SECURITY_RUNBOOK.md
@@ -1,0 +1,19 @@
+# Security Runbook
+
+## Secret Rotation Checklist
+
+- Keep production secrets in an external secret manager (for Fly, use `fly secrets`).
+- Generate a new value for each rotated secret (`DJANGO_SECRET_KEY`, SMTP credentials, API keys).
+- Set new secrets in production and deploy.
+- Verify app startup and key flows (`manage.py check`, login, password reset).
+- Revoke old secret values after verification succeeds.
+- Record rotation date, owner, and impacted environments.
+
+## Incident Response Checklist (Secret Exposure)
+
+- Contain immediately: remove exposed value from code, logs, and shared channels.
+- Rotate affected secrets in production first, then staging/local copies.
+- Redeploy services that consume rotated secrets.
+- Invalidate active sessions/tokens if auth-related secrets were exposed.
+- Review audit logs and deployment history to identify unauthorized access.
+- Document timeline, remediation, and follow-up prevention actions.

--- a/backend/core/core/settings.py
+++ b/backend/core/core/settings.py
@@ -16,6 +16,22 @@ environ.Env.read_env(BASE_DIR.parent / ".env")
 
 
 
+def _looks_like_placeholder_secret(value: str) -> bool:
+    normalized = (value or "").strip().lower()
+    if not normalized:
+        return True
+    placeholder_tokens = (
+        "replace-with",
+        "replace_me",
+        "changeme",
+        "change-me",
+        "example",
+        "unsafe-dev-key",
+    )
+    return any(token in normalized for token in placeholder_tokens)
+
+
+
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = env("DJANGO_SECRET_KEY", default="unsafe-dev-key")
 
@@ -24,8 +40,10 @@ DEBUG = env.bool("DJANGO_DEBUG", default=False)
 default_allowed_hosts = ["127.0.0.1", "localhost", "0.0.0.0", "testserver"] if DEBUG else []
 ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", default=default_allowed_hosts)
 
-if not DEBUG and SECRET_KEY == "unsafe-dev-key":
-    raise ImproperlyConfigured("DJANGO_SECRET_KEY must be set when DJANGO_DEBUG=False")
+if not DEBUG and _looks_like_placeholder_secret(SECRET_KEY):
+    raise ImproperlyConfigured(
+        "DJANGO_SECRET_KEY must be set to a real externally managed secret when DJANGO_DEBUG=False"
+    )
 
 if not DEBUG and not ALLOWED_HOSTS:
     raise ImproperlyConfigured("DJANGO_ALLOWED_HOSTS must be set when DJANGO_DEBUG=False")
@@ -169,6 +187,11 @@ if email_provider == "smtp":
     EMAIL_USE_TLS = env.bool("EMAIL_USE_TLS", default=True)
     EMAIL_USE_SSL = env.bool("EMAIL_USE_SSL", default=False)
     EMAIL_TIMEOUT = env.int("EMAIL_TIMEOUT", default=10)
+
+    if not DEBUG and not EMAIL_HOST_PASSWORD.strip():
+        raise ImproperlyConfigured(
+            "EMAIL_HOST_PASSWORD must be set when EMAIL_PROVIDER=smtp and DJANGO_DEBUG=False"
+        )
 else:
     EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -19,11 +19,11 @@ dependencies = [
     { name = "dj-database-url" },
     { name = "django" },
     { name = "django-cors-headers" },
+    { name = "django-environ" },
     { name = "djangorestframework" },
     { name = "djoser" },
     { name = "gunicorn" },
     { name = "psycopg", extra = ["binary"] },
-    { name = "python-environ" },
 ]
 
 [package.metadata]
@@ -31,11 +31,11 @@ requires-dist = [
     { name = "dj-database-url", specifier = ">=3.0.1" },
     { name = "django", specifier = ">=6.0.3" },
     { name = "django-cors-headers", specifier = ">=4.9.0" },
+    { name = "django-environ", specifier = ">=0.11.2" },
     { name = "djangorestframework", specifier = ">=3.16.1" },
     { name = "djoser", specifier = ">=2.3.3" },
     { name = "gunicorn", specifier = ">=22.0.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.9" },
-    { name = "python-environ", specifier = ">=0.4.54" },
 ]
 
 [[package]]
@@ -235,6 +235,15 @@ wheels = [
 ]
 
 [[package]]
+name = "django-environ"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/3c/60983e6ec9b24a8d8588eecebfd21123cba980bce0a905807a27692f0860/django_environ-0.13.0.tar.gz", hash = "sha256:6c401e4c219442c2c4588c2116d5292b5484a6f69163ed09cd41f3943bfb645f", size = 63529, upload-time = "2026-02-18T01:08:08.791Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/00/3767393ece946084e1c6830a33ffb8e39d68642e27ad5ac7d4c8bd5de866/django_environ-0.13.0-py3-none-any.whl", hash = "sha256:37799d14cd78222c6fd8298e48bfe17965ff8e586091ad66a463e52e0e7b799e", size = 20682, upload-time = "2026-02-18T01:08:07.359Z" },
+]
+
+[[package]]
 name = "djangorestframework"
 version = "3.16.1"
 source = { registry = "https://pypi.org/simple" }
@@ -382,12 +391,6 @@ wheels = [
 crypto = [
     { name = "cryptography" },
 ]
-
-[[package]]
-name = "python-environ"
-version = "0.4.54"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0c/5d/8d4462fe29d3d3357eaac0f8321b7d0e77d0a4ea64505be1e6a90fba42dc/python-environ-0.4.54.tar.gz", hash = "sha256:6249a14057f95aba3b4906d73276f770e01e659f8098b3f3b34295feac42865b", size = 22947, upload-time = "2020-04-13T06:42:49.443Z" }
 
 [[package]]
 name = "python3-openid"


### PR DESCRIPTION
## Summary
- Harden production startup checks to reject placeholder/unsafe `DJANGO_SECRET_KEY` values and require `EMAIL_HOST_PASSWORD` when SMTP is enabled.
- Update backend security requirements and validation examples to reflect fail-closed production behavior.
- Add `backend/SECURITY_RUNBOOK.md` with secret rotation and secret exposure incident response checklists.
- Sync `backend/uv.lock` to the django-environ dependency set used by the backend.

## Validation
- `DJANGO_DEBUG=True uv run python manage.py check`
- `DJANGO_DEBUG=True uv run python manage.py test` (20 tests passing)
- `DJANGO_DEBUG=False DJANGO_SECRET_KEY=real-secret DJANGO_ALLOWED_HOSTS=example.com uv run python manage.py check`
- `DJANGO_DEBUG=False DJANGO_ALLOWED_HOSTS=example.com uv run python manage.py check` (fails as expected)
- `DJANGO_DEBUG=False DJANGO_SECRET_KEY=real-secret DJANGO_ALLOWED_HOSTS=example.com EMAIL_PROVIDER=smtp EMAIL_HOST=smtp.sendgrid.net EMAIL_HOST_PASSWORD= uv run python manage.py check` (fails as expected)